### PR TITLE
fix table caption alignment

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -54,6 +54,14 @@
   set enum(indent: 10pt, body-indent: 9pt)
   set list(indent: 10pt, body-indent: 9pt)
 
+  // Configure tables.
+  show figure.where(kind: table): fig => {
+    set figure.caption(position: top)
+    set figure.caption(separator: [ \ ])
+    align(center, smallcaps(fig.caption))
+    align(center, fig.body)
+  }
+
   // Configure headings.
   set heading(numbering: "I.A.1.")
   show heading: it => locate(loc => {


### PR DESCRIPTION
Closes #2 

There are some caveats: on macOS the small caps don't show. Not sure about other systems or font versions. 

This may be related to `smallcaps` implementation, see the [docs](https://typst.app/docs/reference/text/smallcaps/). 